### PR TITLE
Update: verify omni binary in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
-  test:
+  format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,7 +24,38 @@ jobs:
             echo "$unformatted"
             exit 1
           fi
-      - name: Build
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build packages
         run: go build ./...
       - name: Test
         run: go test ./...
+
+  build-cli:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build omni binary
+        run: mkdir -p bin && go build -o bin/omni ./cmd/omni
+      - name: Smoke test omni binary
+        run: |
+          test -x ./bin/omni
+          ./bin/omni version | grep -Fx "dev"
+          ./bin/omni --help >/tmp/omni-help.txt
+          grep -Fq "omni - Omni CLI" /tmp/omni-help.txt
+          grep -Fq "Usage:" /tmp/omni-help.txt
+          ./bin/omni auth --help >/tmp/omni-auth-help.txt
+          grep -Fq "omni auth commands:" /tmp/omni-auth-help.txt


### PR DESCRIPTION
## Why are we changing this?

The existing CI only verified formatting, package builds, and tests. That can still miss breakage in the actual shipped CLI entrypoint. We want CI to prove that the `omni` binary itself builds and responds to basic commands on supported runner platforms.

## What has changed?

- Split the workflow into separate `format`, `test`, and `build-cli` jobs.
- Added explicit `contents: read` permissions to keep the workflow minimal.
- Added a `build-cli` matrix on `ubuntu-latest` and `macos-latest`.
- Built the real binary with `go build -o bin/omni ./cmd/omni`.
- Added smoke checks for `./bin/omni version`, `./bin/omni --help`, and `./bin/omni auth --help`.

## How to test it and expected results?

1. Run `go test ./...`.
Expected: all tests pass.

2. Run `go build -o bin/omni ./cmd/omni`.
Expected: the binary is created successfully.

3. Run `./bin/omni version`.
Expected: prints `dev`.

4. Run `./bin/omni --help` and `./bin/omni auth --help`.
Expected: both commands print help output successfully.

5. Open the GitHub Actions run for this PR.
Expected: `format`, `test`, and `build-cli` jobs all pass, with `build-cli` running on both Ubuntu and macOS.

## Checklist:

- [x] My pull request represents one logical piece of work.
- [x] My commits are related to the pull request and look clean.
- [x] My code follows our coding conventions.
- [x] My code has appropriate tests and documentation.
